### PR TITLE
Removed a dead sprite in the endgame scene

### DIFF
--- a/src/scenes/EndGame.js
+++ b/src/scenes/EndGame.js
@@ -12,7 +12,6 @@ export default class EndGame extends Phaser.Scene {
 
 	create() {
 		this.add.text(200, 100, 'Gameover', {font: '80px Courier', fill: HEADINGS})
-		this.add.image(400, 400, 'background').setAlpha(0.2)
 
 		this.score_Display = this.add.text(240, 200, 'Your Score:', {font: '36px Courier', fill: TEXT})
 		this.score_Display.setText('Your Score: ' + this.score)


### PR DESCRIPTION
Very quick PR to remove an image that was being added in the endgame that we no longer need.
Showed up faintly as a box with a cross through it as the asset was not loading.