### PR TITLE
:wrench: fix players detecting the other players crash/flips

### DIFF
--- a/src/scenes/MainGame.js
+++ b/src/scenes/MainGame.js
@@ -34,10 +34,10 @@ export default class MainGame extends Phaser.Scene {
 			Math.seed = gameId.charCodeAt(4)
 
 			this.player = new Multiplayer(this, gameId, opponents, socket)
- 
+
 			// disconnent socket from server on scene shutdown
 			this.events.on('shutdown', this.player.shutdown, this.player)
-			
+
 		} else {
 			Math.seed = Math.random()
 			this.player = new Player(this, P1)
@@ -54,7 +54,7 @@ export default class MainGame extends Phaser.Scene {
 		this.progressBox.fillStyle(GREY, 0.2)
 		this.progressBox.fillRect(530, 30, 200, 12)
 		this.progressBox.setScrollFactor(0)
-		
+
 		this.player.create()
 
 		// camera set zoom level and follow me!
@@ -105,14 +105,16 @@ export default class MainGame extends Phaser.Scene {
 			this.player.hitObstacle()
 			stats.reduceScore(HIT_OBSTACLE_POINT_DEDUCTION)
 			stats.increaseHits()
-		} else if (fixtureA.m_userData === HILL_TAG && fixtureB.m_userData === HEAD_SENSOR) {
+		} else if (fixtureA.m_userData === HILL_TAG && fixtureB.m_body === this.player.body
+						&& fixtureB.m_userData === HEAD_SENSOR) {
 			// When the player's head is touching the ground then they have fallen over
 			const {left, right} = this.hill.getBounds(this.player.body.getPosition().x)
 			const newAngle = calculateAngle(left, right)
 			this.player.fellOver(newAngle)
 			stats.reduceScore(FAILED_LANDING_POINT_DEDUCTION)
 			stats.increaseFalls()
-		} else if (fixtureA.m_userData === HILL_TAG && fixtureB.m_userData == BOARD_SENSOR) {
+		} else if (fixtureA.m_userData === HILL_TAG && fixtureB.m_body === this.player.body
+						&& fixtureB.m_userData == BOARD_SENSOR) {
 			if (!this.player.onGround) {
 				// We weren't on the ground, but we will be now
 				const numFlips = Math.round(Math.abs(this.player.rotationAngleCount / (2 * Math.PI)))
@@ -129,7 +131,8 @@ export default class MainGame extends Phaser.Scene {
 		const fixtureA = e.getFixtureA()
 		const fixtureB = e.getFixtureB()
 
-		if (fixtureA.m_userData === HILL_TAG && fixtureB.m_userData == BOARD_SENSOR) {
+		if (fixtureA.m_userData === HILL_TAG && fixtureB.m_body === this.player.body
+						&& fixtureB.m_userData == BOARD_SENSOR) {
 			// Subtract ground contact
 			this.player.onGround--
 
@@ -165,9 +168,9 @@ export default class MainGame extends Phaser.Scene {
 		while (this.accumMS >= this.hzMS) {
 			this.accumMS -= this.hzMS
 			this.world.step(1/60)
-			
+
 			this.player.update(this.hill.endX)
-		
+
 			// End of game if player's x position past last hill segment x position
 			if (this.player.xPos > (this.hill.endX + 20)) {
 				this.scene.stop('MainGame')


### PR DESCRIPTION
Added extra check to the maingame to check whether player sensors are of your own player. 

Previously if you crashed in your own game it would make your friend's crash as well and they shared your flip points.