### PR TITLE
Broadcast data upon receiving :syringe:

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Sam Wemyss <samuel.wemyss@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": "10.x.x",
+    "node": ">=10.x.x",
     "yarn": "1.x.x"
   },
   "devDependencies": {

--- a/server/index.js
+++ b/server/index.js
@@ -82,9 +82,10 @@ io.on('connection', function(socket) {
 
 		games[gameId][socket.id] = data
 
+		const packet = Object.assign(games[gameId][socket.id], {id: socket.id})
 
 		// Send the data to all the other players in this game
-		socket.broadcast.to(gameId).emit('update-players', games[gameId])
+		socket.broadcast.to(gameId).emit('update-players', packet)
 	})
 
 	socket.on('start-game', function(gameId) {

--- a/src/lib/Multiplayer.js
+++ b/src/lib/Multiplayer.js
@@ -90,21 +90,19 @@ export default class Multiplayer extends Player {
 	 */
 	registerForUpdates() {
 		this.socket.on('update-players', playersData => {
-			for (const id in playersData) {
-				// skip myself
-				if (id === this.socket.id) continue
+			const { pos, angle, lv, av, onGround, id } = playersData
+			// skip myself
+			if (id === this.socket.id) return
 
-				const body = this.opponents[id].body
-				const { pos, angle, lv, av, onGround } = playersData[id]
+			const body = this.opponents[id].body
 
-				// Make things buttery smooth and in sync with difference vector
-				const posDelta = new Vec2(pos).sub(body.getPosition())
+			// Make things buttery smooth and in sync with difference vector
+			const posDelta = new Vec2(pos).sub(body.getPosition())
 
-				body.setLinearVelocity(new Vec2(lv).add(posDelta))
-				body.setAngle(angle)
-				body.setAngularVelocity(av)
-				this.opponents[id].onGround = onGround
-			}
+			body.setLinearVelocity(new Vec2(lv).add(posDelta))
+			body.setAngle(angle)
+			body.setAngularVelocity(av)
+			this.opponents[id].onGround = onGround			
 		})
 	}
 


### PR DESCRIPTION
First the issue:
- with multiplayer, u send null data to the client on the first receiving of data (ie. client1 gives data to server, server attempts to broadcast client1 and client2, but has no client2 data so broadcasts null)
- client attempts to destructure null. In 2 player it doesnt matter because it gets caught as its your own id, in 3+ need to explicitly check for null
- null then leads to undefined positions/angles etc which causes physics to go haywire
- hence one solution is to: 
``if (id === this.socket.id || Object.keys(playersData[id]).length === 0) continue``

Improvement:
- since the server is essentially just passing data forward, why not reduce bandwidth and only send whats new rather than entire game state
- saves needing to check null (although should do anyway hey lol) since guaranteed to send only filled data
